### PR TITLE
Update create_plane migration table

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 3.2.2p53
+   ruby 3.1.3p185
 
 BUNDLED WITH
    2.4.7

--- a/app/controllers/api/v1/planes_controller.rb
+++ b/app/controllers/api/v1/planes_controller.rb
@@ -16,7 +16,7 @@ class Api::V1::PlanesController < ApplicationController
     @plane.user = @current_user
 
     if @plane.save
-      render json: { plane: @plane, message: 'Plane created successfully' }, status: :created
+      render json: { planeID: @plane.id, message: 'Plane created successfully' }, status: :created
     else
       render json: { errors: @plane.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,7 +1,7 @@
 class UserSerializer
   include JSONAPI::Serializer
   extend JsonWebToken
-  attributes :name, :email
+  attributes :name, :email, :id
 
   meta do |user|
     { token: jwt_encode(user_id: user.id) }

--- a/db/migrate/20230331094417_create_planes.rb
+++ b/db/migrate/20230331094417_create_planes.rb
@@ -9,7 +9,7 @@ class CreatePlanes < ActiveRecord::Migration[7.0]
       t.integer :price
       t.string :model
       t.date :year_of_manufacture
-      t.time :life_span
+      t.string :life_span
       t.float :fees
 
       t.references :user, null: false, foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,7 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_04_141831) do
     t.integer "price"
     t.string "model"
     t.date "year_of_manufacture"
-    t.time "life_span"
+    t.string "life_span"
     t.float "fees"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
Three changes major changes were made in this branch:

- [ ] Update the lifespan table type from `time` to `string` in the create plane migration.
- [ ] Return only plane id after a new plane has been created.
- [ ] Include the user id in the returned user attribute.