### PR TITLE
Fix date conflict bug

### DIFF
--- a/app/controllers/api/v1/planes_reservations_controller.rb
+++ b/app/controllers/api/v1/planes_reservations_controller.rb
@@ -12,11 +12,16 @@ class Api::V1::PlanesReservationsController < ApplicationController
     plane_reservation = @current_user.plane_reservations.build(plane_reservation_params)
 
     if plane_reservation.start_time.present? && plane_reservation.end_time.present?
-      duration = ((plane_reservation.end_time - plane_reservation.start_time) / 60).to_i
-      plane_reservation.duration = duration
+      duration_in_minutes = ((plane_reservation.end_time - plane_reservation.start_time) / 60).to_i
+      plane_reservation.duration = duration_in_minutes
 
       if plane_reservation.save
-        render json: { plane_reservation:, duration: }, status: :created
+        duration_in_hours = duration_in_minutes / 60
+        duration_in_minutes %= 60
+        duration_formatted = format('%<duration_in_hours>d:%<duration_in_minutes>02d',
+                                    duration_in_hours:, duration_in_minutes:)
+
+        render json: { plane_reservation:, duration: duration_formatted }, status: :created
       else
         render json: { errors: plane_reservation.errors.full_messages }, status: :unprocessable_entity
       end

--- a/app/models/plane_reservation.rb
+++ b/app/models/plane_reservation.rb
@@ -2,13 +2,32 @@ class PlaneReservation < ApplicationRecord
   belongs_to :user
   belongs_to :plane
 
-  validates :date, :user_id, :plane_id, :start_time, :end_time, presence: true
+  validates :start_time, :end_time, :date, presence: true
 
   validate :no_conflicting_reservations
+  def as_json(options = {})
+    options[:methods] ||= []
+    options[:methods] << :start_time_formatted
+    options[:methods] << :end_time_formatted
+
+    super(options).tap do |hash|
+      hash['start_time'] = start_time.strftime('%H:%M')
+      hash['end_time'] = end_time.strftime('%H:%M')
+    end
+  end
+
+  def start_time_formatted
+    start_time.strftime('%H:%M')
+  end
+
+  def end_time_formatted
+    end_time.strftime('%H:%M')
+  end
 
   def no_conflicting_reservations
     if PlaneReservation.where(plane_id:)
-        .where('start_time < ? AND end_time > ?', end_time, start_time)
+        .where('date = ? AND ((start_time < ? AND end_time > ?) OR (start_time >= ? AND start_time < ?))',
+               date, end_time, start_time, start_time, end_time)
         .where.not(id:)
         .exists?
       errors.add(:base, 'This plane is already reserved at this time.')


### PR DESCRIPTION
In this milestone, I fixed the date, start time, and end time reset error. Now the user can reserve the plane based on the dates of choice, without the start time and end time being reset.